### PR TITLE
Namespace wrap unminified assets. Fixes #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 test/scratch/
 test/unit/scratch/
 
+# Webstorm
+.idea
+
 # Sublime Text
 *.sublime-*
 

--- a/lib/generateFileFactory.js
+++ b/lib/generateFileFactory.js
@@ -100,12 +100,10 @@ module.exports = function (sourceDir, targetDir, namespaceName, uglify, log) {
 
         asyncCallback();
       },
-      writeUglifiedFile: function (asyncCallback) {
-        if (!uglify) {
-          return asyncCallback();
-        }
-
-        fs.writeFile(destination, result.code, options, asyncCallback);
+      writeFile: function (asyncCallback) {
+        // If the uglify flag isn't preset, just write the raw namespace wrapped contents.
+        var contentToWrite = uglify ? result.code : contents;
+        fs.writeFile(destination, contentToWrite, options, asyncCallback);
       },
       writeSourceMapFile: function (asyncCallback) {
         if (!uglify) {


### PR DESCRIPTION
The generator was failing to write the "wrapped" version of the asset which made them unusable. The wrapper looks like the following:

```
(function (define) {
// Asset code goes here
}(window.TEST._staticAssetRegistry.define));
```

In master, this wrapper is not present on the generated unminified files.