### PR TITLE
Make sourcemaps optional for deployment. Fixes #13

### DIFF
--- a/lib/deployToS3.js
+++ b/lib/deployToS3.js
@@ -109,14 +109,9 @@ module.exports = function (config, callback) {
           return asyncCallback(error);
         }
 
-        if (!mapFilePaths.length) {
-          return asyncCallback(new Error(util.format(
-            'No map files found under %s. Is this source directory correct?',
-            config.sourceDir
-          )));
+        if (mapFilePaths.length) {
+          filePaths = filePaths.concat(mapFilePaths);
         }
-
-        filePaths = filePaths.concat(mapFilePaths);
         asyncCallback();
       });
     },


### PR DESCRIPTION
If an asset is generated as without uglification, sourcemaps will not be present; Therefore, It is not an error case if .map files are not present. This PR removes the error case.