### PR TITLE
Add flag to enable gzip compression

### DIFF
--- a/lib/deployToS3.js
+++ b/lib/deployToS3.js
@@ -125,6 +125,7 @@ module.exports = function (config, callback) {
           optionsObjects.push({
             bucket: config.bucket,
             contentType: contentTypes[path.extname(filePath)],
+            contentEncoding: config.compress ? 'gzip' : 'identity',
             filePath: filePath,
             key: keyPrefix + path.basename(filePath),
             log: config.log,

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -57,7 +57,8 @@ module.exports = function (config, callback) {
         config.targetDir,
         config.namespaceName,
         config.uglify,
-        config.log
+        config.log,
+        config.compress
       );
       var assetNameCombinations = [];
 

--- a/lib/generateFileFactory.js
+++ b/lib/generateFileFactory.js
@@ -11,6 +11,7 @@ var async = require('async');
 var fs = require('fs-extra');
 var concat = require('concat-files');
 var uglifyJs2 = require('uglify-js2');
+var zlib = require('zlib');
 
 // Local.
 var pkg = require('../package.json');
@@ -25,7 +26,7 @@ var pkg = require('../package.json');
  * @param {Boolean} log If true, log results to console.
  * @return {Function} A generator function of the form function (assetNames).
  */
-module.exports = function (sourceDir, targetDir, namespaceName, uglify, log) {
+module.exports = function (sourceDir, targetDir, namespaceName, uglify, log, compress) {
   /**
    * Generate a file given the ordered asset names.
    *
@@ -99,6 +100,42 @@ module.exports = function (sourceDir, targetDir, namespaceName, uglify, log) {
         );
 
         asyncCallback();
+      },
+      compress: function (asyncCallback) {
+        if (!compress) {
+          return asyncCallback();
+        }
+        if (uglify) {
+          async.parallel([
+            function (done) {
+              zlib.gzip(result.code, function (err, zippedResult) {
+                if (err) {
+                  return done(err);
+                }
+                result.code = zippedResult;
+                done();
+              });
+            },
+            function (done) {
+              zlib.gzip(result.map, function (err, zippedResult) {
+                if (err) {
+                  return done(err);
+                }
+                result.map = zippedResult;
+                done();
+              });
+            }
+          ], asyncCallback);
+        }
+        else {
+          zlib.gzip(contents, function (err, zippedResult) {
+            if (err) {
+              return asyncCallback(err);
+            }
+            contents = zippedResult;
+            asyncCallback();
+          });
+        }
       },
       writeFile: function (asyncCallback) {
         // If the uglify flag isn't preset, just write the raw namespace wrapped contents.

--- a/lib/uploadToS3.js
+++ b/lib/uploadToS3.js
@@ -49,6 +49,7 @@ module.exports = function uploadToS3 (options, callback) {
     CacheControl: 'max-age=2592000',
     // Not strictly necessary, but helpful for human inspection.
     ContentType: options.contentType,
+    ContentEncoding: options.contentEncoding,
     Key: options.key
   };
 

--- a/test/unit/lib/generateFileFactory.spec.js
+++ b/test/unit/lib/generateFileFactory.spec.js
@@ -8,6 +8,7 @@ var path = require('path');
 
 // NPM.
 var fs = require('fs-extra');
+var zlib = require('zlib');
 
 // Local.
 var generateFileFactory = require('../../../lib/generateFileFactory');
@@ -21,7 +22,7 @@ describe('lib/generateFileFactory', function () {
   });
 
   afterEach(function () {
-    fs.removeSync(targetDir);
+    //fs.removeSync(targetDir);
   });
 
   it('functions as expected', function (done) {
@@ -48,5 +49,32 @@ describe('lib/generateFileFactory', function () {
       done(error);
     });
 
+  });
+
+  it('can compress assets', function (done) {
+    var assetDir = path.resolve(__dirname, '../../fixtures/assets');
+    var namespaceName = 'TEST';
+    var assetNames = [
+      'asset-one@1.0.0',
+      'asset-two@1.0.0'
+    ];
+    var uglify = true;
+    var log = true;
+    var compress = true;
+
+    var generateFile = generateFileFactory(
+      assetDir,
+      targetDir,
+      namespaceName,
+      uglify,
+      log,
+      compress
+    );
+
+    generateFile(assetNames, function (error) {
+      // Will throw if the file is not gzip.
+      zlib.gunzipSync(fs.readFileSync(path.resolve(targetDir, assetNames.join('+') + '.js')));
+      done(error);
+    });
   });
 });

--- a/test/unit/lib/generateFileFactory.spec.js
+++ b/test/unit/lib/generateFileFactory.spec.js
@@ -22,7 +22,7 @@ describe('lib/generateFileFactory', function () {
   });
 
   afterEach(function () {
-    //fs.removeSync(targetDir);
+    fs.removeSync(targetDir);
   });
 
   it('functions as expected', function (done) {

--- a/test/unit/lib/uploadToS3.spec.js
+++ b/test/unit/lib/uploadToS3.spec.js
@@ -75,4 +75,14 @@ describe('lib/uploadToS3', function () {
       done();
     });
   });
+
+  it('sets content-encoding headers when compression is true', function (done) {
+    options.contentEncoding = 'gzip';
+
+    uploadToS3(options, function (error) {
+      var params = uploadToS3.s3Client.putObject.getCall(0).args[0];
+      expect(params.ContentEncoding).to.equal(options.contentEncoding);
+      done(error);
+    });
+  })
 });


### PR DESCRIPTION
Since SAS is responsible for uploading to S3, we need the ability to have the library handle gzip compression of assets for cases where we cant to compress ahead of time (as opposed to having the CDN do it).