### PR TITLE
UIA-10367 - Adding configuration to uglifyJS to ignore adding unicode to regex. Adding source map for library files.

### DIFF
--- a/lib/generateFileFactory.js
+++ b/lib/generateFileFactory.js
@@ -85,6 +85,9 @@ module.exports = function (sourceDir, targetDir, namespaceName, uglify, log, com
             join_vars: true,
             drop_console: true
           },
+          output: {
+            ascii_only: true,
+          },
           fromString: true,
           mangle: true,
           // The map is in the same directory, and thus we just need the name.
@@ -98,7 +101,8 @@ module.exports = function (sourceDir, targetDir, namespaceName, uglify, log, com
           /"sources":\["[^"]*"\]/,
           '"sources":["' + encodeURIComponent(path.basename(destination)) + '"]'
         );
-
+        var sourceMapStr = result.code.indexOf('sourceMappingURL');
+        result.code = result.code.slice(0, sourceMapStr) + result.code.slice(sourceMapStr).replace(/@/g, '%40').replace('+', '%2B') + '.map'
         asyncCallback();
       },
       compress: function (asyncCallback) {


### PR DESCRIPTION
## JIRA Ticket

**If this is not a Firebird Team Ticket (UIA), please make one so it gets tracked/noticed.**
[UIA-10367](https://bits.bazaarvoice.com/jira/browse/UIA-10367)

## Problem

- UglifyJS is converting the regExp to unicode which ends up generating invalid characters in the library files.
- Console warning observed for sourcemap not generated for library files. This is for debugging purpose.

## Solution

 -  Adding ascii_only attribute to the output object.
 -  Added SourceMap to the Javascript libraries to avoid console warnings. 

## Verification
